### PR TITLE
Unconfirmed line issue & Not Writing All QBS + Quests

### DIFF
--- a/src/cmd/qb-list/qb-list.go
+++ b/src/cmd/qb-list/qb-list.go
@@ -79,8 +79,10 @@ func writeQbFile(list parser.ServerQbList, outputDirectory string) error {
 		if err != nil {
 			return fmt.Errorf("error writing %v header: %v", fileName, err)
 		}
+		writer.Flush()
 	}
 	csvWriter := csv.NewWriter(writer)
+	defer f.Close()
 
 	var unconfirmed []*parser.QB
 	// First write all the confirmed QBs
@@ -97,8 +99,12 @@ func writeQbFile(list parser.ServerQbList, outputDirectory string) error {
 
 	// Now write the rest of the unconfirmed QBs
 	for _, qb := range unconfirmed {
-		csvWriter.Write(qb.GetRecord())
+		err = csvWriter.Write(qb.GetRecord())
+		if err != nil {
+			return err
+		}
 	}
+	csvWriter.Flush()
 
 	return nil
 }
@@ -120,5 +126,6 @@ func writeQuestFile(list parser.ServerQuestList, outputDirectory string) error {
 	for _, quest := range list.Quests {
 		csvWriter.Write(quest.GetRecord())
 	}
+	csvWriter.Flush()
 	return nil
 }

--- a/src/pkg/parser/parser.go
+++ b/src/pkg/parser/parser.go
@@ -183,7 +183,8 @@ func (p *Parser) parseServerQb(responseChan chan ServerQbList, errChan chan erro
 		}
 		if len(records) > 0 && strings.Contains(records[0], "unconfirmed data dump from server") {
 			unconfirmed = true
-			list.UnconfirmedLine = records[0]
+			records = append(records, "\n")
+			list.UnconfirmedLine = strings.Join(records, ",")
 			continue
 		}
 		err = list.addQb(records, unconfirmed)


### PR DESCRIPTION
Writers weren't calling a final flush before exiting, so the output files were missing a few QBs and Quests from the input
Additionally, unconfirmed line was only capturing the initial text not the full line, causing some format issues.